### PR TITLE
Fix changes to cmakelists.txt causing full rebuilds

### DIFF
--- a/cmake/ExternalProjects.cmake
+++ b/cmake/ExternalProjects.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 
 function(add_catch2 IN_TARGET)
     FetchContent_Declare(
-        Catch2
+        catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
         GIT_TAG v3.4.0
     )
@@ -21,18 +21,20 @@ endfunction()
 
 function(add_tl_expected IN_TARGET)
 
-    set(EXPECTED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extern/tl-expected/)
-    file(DOWNLOAD
-        https://raw.githubusercontent.com/TartanLlama/expected/master/include/tl/expected.hpp
-        ${EXPECTED_DIR}/include/tl/expected.hpp
-    )
+    FetchContent_Declare(tl_expected
+        GIT_REPOSITORY https://github.com/TartanLlama/expected.git
+        GIT_TAG master
+        )
+    
+    FetchContent_GetProperties(tl_expected)
+    if (NOT tl_expected_POPULATED)
+        FetchContent_Populate(tl_expected)
+    endif()
 
-    target_include_directories(${IN_TARGET} PUBLIC ${EXPECTED_DIR}/include)
-
-    file(GLOB_RECURSE EXPECTED_HEADERS "${EXPECTED_DIR}/include/*.h*" )
-    target_sources(ShaderTestFramework PRIVATE 
-        ${EXPECTED_HEADERS})
-    source_group(TREE ${EXPECTED_DIR}/include PREFIX "ThirdParty/tl-expected" FILES ${EXPECTED_HEADERS})
+    file(GLOB_RECURSE EXPECTED_HEADERS "${tl_expected_SOURCE_DIR}/include/*.h*" )
+    target_include_directories(${IN_TARGET} PUBLIC ${tl_expected_SOURCE_DIR}/include)
+    target_sources(${IN_TARGET} PRIVATE ${EXPECTED_HEADERS})
+    source_group(TREE ${tl_expected_SOURCE_DIR}/include PREFIX "ThirdParty/tl-expected" FILES ${EXPECTED_HEADERS})
     return()
 endfunction()
 

--- a/cmake/ExternalProjects.cmake
+++ b/cmake/ExternalProjects.cmake
@@ -50,18 +50,18 @@ function(add_tuplet IN_TARGET)
 endfunction()
 
 function(add_float16 IN_TARGET)
+    FetchContent_Declare(float16_fetch
+        GIT_REPOSITORY https://github.com/KStocky/float16_t.git
+        GIT_TAG master
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        )
+    
+    FetchContent_MakeAvailable(float16_fetch)
 
-    set(EXPECTED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extern/float16/)
-    file(DOWNLOAD
-        https://raw.githubusercontent.com/fengwang/float16_t/master/float16_t.hpp
-        ${EXPECTED_DIR}/include/float16/float16_t.hpp
-    )
-
-    target_include_directories(${IN_TARGET} PUBLIC ${EXPECTED_DIR}/include)
-
-    file(GLOB_RECURSE EXPECTED_HEADERS "${EXPECTED_DIR}/include/*.h*" )
-    target_sources(ShaderTestFramework PRIVATE 
-        ${EXPECTED_HEADERS})
-    source_group(TREE ${EXPECTED_DIR}/include PREFIX "ThirdParty/float16" FILES ${EXPECTED_HEADERS})
+    file(GLOB_RECURSE FLOAT16_HEADERS "${float16_fetch_SOURCE_DIR}/include/*.h*" )
+    target_include_directories(${IN_TARGET} PUBLIC ${float16_fetch_SOURCE_DIR}/include)
+    target_sources(${IN_TARGET} PRIVATE ${FLOAT16_HEADERS})
+    source_group(TREE ${float16_fetch_SOURCE_DIR}/include PREFIX "ThirdParty/float16" FILES ${FLOAT16_HEADERS})
     return()
 endfunction()

--- a/cmake/ExternalProjects.cmake
+++ b/cmake/ExternalProjects.cmake
@@ -55,8 +55,6 @@ function(add_float16 IN_TARGET)
     FetchContent_Declare(float16_fetch
         GIT_REPOSITORY https://github.com/KStocky/float16_t.git
         GIT_TAG master
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
         )
     
     FetchContent_MakeAvailable(float16_fetch)


### PR DESCRIPTION
The issue was caused by using an unconditional file(DOWNLOAD ...) to grab the float16 library. This would grab a whole new copy every time a cmakelists was changed, which then caused a full recompile since a root header had been updated. I have fixed this just by using fetchcontent. I also made the same change to tl-expected. However, it is a little different since calling FetchContent_MakeAvailable causes issues for tl-expected. In this case we just use FetchContent to download and manage versioning. We do the including of source information ourselves.

Fixes #44 