### PR TITLE
Change requirement for std::formattable to greater than 1938

### DIFF
--- a/src/ShaderTestFramework/Public/Utility/Concepts.h
+++ b/src/ShaderTestFramework/Public/Utility/Concepts.h
@@ -114,7 +114,7 @@ namespace Private
 
 template<typename T, typename CharT>
 concept Formattable =
-#if _MSC_VER > 1937
+#if _MSC_VER > 1938
 std::formattable<T, CharT>;
 #else
 Private::formattable<T, CharT>;


### PR DESCRIPTION
It would seem that 1939 is required to use std::formattable.