### PR TITLE
Upgrading all D3D packages

### DIFF
--- a/cmake/Nuget.cmake
+++ b/cmake/Nuget.cmake
@@ -49,8 +49,8 @@ function(nuget_pkg_get IN_TARGET IN_PKG_NAME IN_VERSION OUT_SUCCEEDED OUT_PKG_PA
     nuget_pkg_already_installed(${IN_TARGET} ${IN_PKG_NAME} PKG_EXISTS CURRENT_VERSION)
 
     if (${PKG_EXISTS})
-        if(CURRENT_VERSION STRGREATER_EQUAL IN_VERSION)
-            if(CURRENT_VERSION STRGREATER IN_VERSION)
+        if(CURRENT_VERSION VERSION_GREATER_EQUAL IN_VERSION)
+            if(CURRENT_VERSION VERSION_GREATER IN_VERSION)
                 message("Package ${IN_PKG_NAME} already has a more up to date version installed. Current: ${CURRENT_VERSION} Requested: ${IN_VERSION}")
             endif()
 
@@ -76,7 +76,7 @@ function(nuget_pkg_get IN_TARGET IN_PKG_NAME IN_VERSION OUT_SUCCEEDED OUT_PKG_PA
     if (${STATUS_CODE} EQUAL 0)
 
         message(STATUS "${IN_PKG_NAME} download complete!")
-        if (${PKG_EXISTS} AND CURRENT_VERSION STRLESS IN_VERSION)
+        if (${PKG_EXISTS} AND CURRENT_VERSION VERSION_LESS IN_VERSION)
             message("Deleting old version ${CURRENT_VERSION}")
             file(REMOVE_RECURSE ${PKG_DIR})
         endif()

--- a/cmake/NugetPackages.cmake
+++ b/cmake/NugetPackages.cmake
@@ -45,7 +45,7 @@ endfunction()
 
 function(nuget_get_WinPixEventRuntime IN_TARGET OUT_SUCCEEDED OUT_INCLUDE_PATH OUT_BINARY_PATH)
 
-    nuget_pkg_get(${IN_TARGET} "WinPixEventRuntime" "1.0.231030001" ${OUT_SUCCEEDED} PKG_PATH)
+    nuget_pkg_get(${IN_TARGET} "WinPixEventRuntime" "1.0.240308001" ${OUT_SUCCEEDED} PKG_PATH)
 
     if (${${OUT_SUCCEEDED}})
         set(${OUT_INCLUDE_PATH} "${PKG_PATH}/Include")

--- a/cmake/NugetPackages.cmake
+++ b/cmake/NugetPackages.cmake
@@ -34,7 +34,7 @@ endfunction()
 
 function(nuget_get_warp IN_TARGET OUT_SUCCEEDED OUT_BINARY_PATH)
 
-    nuget_pkg_get(${IN_TARGET} "Microsoft.Direct3D.WARP" "1.0.9" ${OUT_SUCCEEDED} PKG_PATH)
+    nuget_pkg_get(${IN_TARGET} "Microsoft.Direct3D.WARP" "1.0.11" ${OUT_SUCCEEDED} PKG_PATH)
 
     if (${${OUT_SUCCEEDED}})
         set(${OUT_BINARY_PATH} "${PKG_PATH}/build/native/amd64")

--- a/cmake/NugetPackages.cmake
+++ b/cmake/NugetPackages.cmake
@@ -5,8 +5,8 @@ include(Nuget)
 function(nuget_get_agility_sdk IN_TARGET OUT_SUCCEEDED OUT_INCLUDE_PATH OUT_BINARY_PATH OUT_SDK_VER)
 
     set(MAJOR_VER "1")
-    set(MINOR_VER "611")
-    set(PATCH_VER "2")
+    set(MINOR_VER "613")
+    set(PATCH_VER "1")
 
     nuget_pkg_get(${IN_TARGET} "Microsoft.Direct3D.D3D12" "${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}" ${OUT_SUCCEEDED} PKG_PATH)
 

--- a/cmake/NugetPackages.cmake
+++ b/cmake/NugetPackages.cmake
@@ -21,7 +21,7 @@ endfunction()
 
 function(nuget_get_dxc IN_TARGET OUT_SUCCEEDED OUT_INCLUDE_PATH OUT_BINARY_PATH OUT_LIB_PATH)
 
-    nuget_pkg_get(${IN_TARGET} "Microsoft.Direct3D.DXC" "1.7.2308.12" ${OUT_SUCCEEDED} PKG_PATH)
+    nuget_pkg_get(${IN_TARGET} "Microsoft.Direct3D.DXC" "1.8.2403.21" ${OUT_SUCCEEDED} PKG_PATH)
 
     if (${${OUT_SUCCEEDED}})
         set(${OUT_INCLUDE_PATH} "${PKG_PATH}/build/native/include")


### PR DESCRIPTION
It would seem that every D3D package got an upgrade for workgraphs recently. This change just upgrades to the latest packages.

Also I use VERSION_GREATER to do comparison of versions rather than STRGREATER now. _