### PR TITLE
Removing <stdfloat>

### DIFF
--- a/src/ShaderTestFramework/Public/Utility/Float.h
+++ b/src/ShaderTestFramework/Public/Utility/Float.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <stdfloat>
 #include "float16/float16_t.hpp"
 
 #include <sstream>


### PR DESCRIPTION
We aren't using this header and it being here only stops people on older compilers from compiling