### PR TITLE
Hlsl202x

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## What is Shader Test Framework
 
-An automation testing framework for testing shader code. Based on Catch2. It uses D3D12 and requires HLSL 2021
+An automation testing framework for testing shader code. Based on Catch2. It uses D3D12 and requires HLSL 202x
 
 It is a framework that is intended to be used with another testing framework such as [Catch2](https://github.com/catchorg/Catch2/tree/devel) to add shader testing capabilities to your already existing test suite. It is currently very experimental, meaning that every merge to main will likely break all old code. The purpose of this project is to explore how we can write unit tests in HLSL.
 

--- a/cmake/NugetPackages.cmake
+++ b/cmake/NugetPackages.cmake
@@ -21,7 +21,7 @@ endfunction()
 
 function(nuget_get_dxc IN_TARGET OUT_SUCCEEDED OUT_INCLUDE_PATH OUT_BINARY_PATH OUT_LIB_PATH)
 
-    nuget_pkg_get(${IN_TARGET} "Microsoft.Direct3D.DXC" "1.8.2403.24" ${OUT_SUCCEEDED} PKG_PATH)
+    nuget_pkg_get(${IN_TARGET} "Microsoft.Direct3D.DXC" "1.8.2405.17" ${OUT_SUCCEEDED} PKG_PATH)
 
     if (${${OUT_SUCCEEDED}})
         set(${OUT_INCLUDE_PATH} "${PKG_PATH}/build/native/include")

--- a/examples/Ex0_MinimalShaderTest/MinimalShaderTest.cpp
+++ b/examples/Ex0_MinimalShaderTest/MinimalShaderTest.cpp
@@ -9,8 +9,6 @@ SCENARIO("MinimalShaderTestExample")
 {
     ShaderTestFixture::Desc desc{};
 
-    desc.HLSLVersion = EHLSLVersion::v2021;
-
     // The HLSL source can either be:
     // 1. a std::filesystem::path that points to the HLSL file under test
     // 2. a std::string containing the HLSL code under test.

--- a/examples/Ex6_ByteReadersAndWriters/ShaderCode/FailingAssertWithByteReader.hlsl
+++ b/examples/Ex6_ByteReadersAndWriters/ShaderCode/FailingAssertWithByteReader.hlsl
@@ -26,7 +26,7 @@ namespace STF
 void Test()
 {
     MyType test1 = (MyType)0;
-    test1.b = 2.0;
+    test1.b = 2.0l;
     MyType test2 = (MyType)0;
     test2.a = 42;
 

--- a/examples/Ex6_ByteReadersAndWriters/ShaderCode/FailingFundamentalTypeTests.hlsl
+++ b/examples/Ex6_ByteReadersAndWriters/ShaderCode/FailingFundamentalTypeTests.hlsl
@@ -7,7 +7,7 @@
 void FailingFundamentalAsserts()
 {
     ASSERT(AreEqual, uint16_t(42), uint16_t(24));
-    ASSERT(NotEqual, float64_t3(2.0, 2.0, 2.0), float64_t3(2.0, 2.0, 2.0));
+    ASSERT(NotEqual, float64_t3(2.0l, 2.0l, 2.0l), float64_t3(2.0l, 2.0l, 2.0l));
     ASSERT(AreEqual, bool2x2(true, true, false, false), bool2x2(false, false, true, true));
 }
 

--- a/src/ShaderTestFramework/Private/D3D12/Shader/ShaderCompiler.cpp
+++ b/src/ShaderTestFramework/Private/D3D12/Shader/ShaderCompiler.cpp
@@ -43,6 +43,19 @@ namespace
 
 }
 
+std::ostream& operator<<(std::ostream& InStream, const CompilationResult& InResult)
+{
+    if (InResult.has_value())
+    {
+        InStream << "Successful shader compilation";
+    }
+    else
+    {
+        InStream << InResult.error();
+    }
+    return InStream;
+}
+
 ShaderCodeSource::ShaderCodeSource(std::string InSourceCode)
 	: m_Source(std::move(InSourceCode))
 {}
@@ -127,6 +140,13 @@ CompilationResult ShaderCompiler::CompileShader(const ShaderCompilationJobDesc& 
     args.push_back(L"-HV");
     args.push_back(ToWString(Enum::UnscopedName(InJob.HLSLVersion).substr(1)));
     args.push_back(L"-WX");
+
+    if (InJob.HLSLVersion >= EHLSLVersion::v202x)
+    {
+        args.push_back(L"-Wconversion");
+        args.push_back(L"-Wdouble-promotion");
+        args.push_back(L"-Whlsl-legacy-literal");
+    }
 
 	if (Enum::EnumHasMask(InJob.Flags, EShaderCompileFlags::AllResourcesBound))
 	{

--- a/src/ShaderTestFramework/Public/D3D12/Shader/ShaderCompiler.h
+++ b/src/ShaderTestFramework/Public/D3D12/Shader/ShaderCompiler.h
@@ -6,6 +6,7 @@
 #include "Utility/Expected.h"
 
 #include <filesystem>
+#include <ostream>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -16,6 +17,8 @@
 namespace fs = std::filesystem;
 
 using CompilationResult = Expected<CompiledShaderData, std::string>;
+
+std::ostream& operator<<(std::ostream& InStream, const CompilationResult& InResult);
 
 class ShaderCodeSource
 {

--- a/src/ShaderTestFramework/Public/D3D12/Shader/ShaderEnums.h
+++ b/src/ShaderTestFramework/Public/D3D12/Shader/ShaderEnums.h
@@ -40,5 +40,6 @@ enum class EHLSLVersion : u8
     v2017,
     v2018,
     v2021,
-    Default = v2018
+    v202x,
+    Default = v202x
 };

--- a/src/ShaderTestFramework/Public/Framework/ShaderTestFixture.h
+++ b/src/ShaderTestFramework/Public/Framework/ShaderTestFixture.h
@@ -24,7 +24,7 @@ public:
         ShaderCodeSource Source;
         std::vector<std::wstring> CompilationFlags;
         D3D_SHADER_MODEL ShaderModel = D3D_SHADER_MODEL_6_6;
-        EHLSLVersion HLSLVersion = EHLSLVersion::v2021;
+        EHLSLVersion HLSLVersion = EHLSLVersion::v202x;
         STF::TestDataBufferLayout TestDataLayout{100u, 10000u, 100u, 800u, 100u};
         std::vector<ShaderMacro> Defines;
     };

--- a/src/ShaderTestFramework/Shader/STF/SectionManagement.hlsli
+++ b/src/ShaderTestFramework/Shader/STF/SectionManagement.hlsli
@@ -215,7 +215,7 @@ namespace ttl
                 
                 for (uint numPackedSectionIds = 0; numPackedSectionIds < 4 && currentSection != -1; ++numPackedSectionIds)
                 {
-                    packedIds = packedIds | (currentSection << (numPackedSectionIds * 8));
+                    packedIds = packedIds | ((uint)currentSection << (numPackedSectionIds * 8u));
                     currentSection = In.Scratch.Sections[currentSection].ParentID;
                 }
 

--- a/src/ShaderTestFramework/Shader/STF/ShaderTestFramework.hlsli
+++ b/src/ShaderTestFramework/Shader/STF/ShaderTestFramework.hlsli
@@ -252,8 +252,8 @@ namespace STF
 
 namespace STF
 {
-    template<typename T, typename U>
-    ttl::enable_if_t<ttl::is_same_v<T, U> > AreEqual(const T InA, const U InB, int InId = -1)
+    template<typename T>
+    void AreEqual(const T InA, const T InB, int InId = -1)
     {
         if (all(InA == InB))
         {
@@ -265,8 +265,8 @@ namespace STF
         }
     }
     
-    template<typename T, typename U>
-    ttl::enable_if_t<ttl::is_same_v<T, U> > NotEqual(const T InA, const U InB, int InId = -1)
+    template<typename T>
+    void NotEqual(const T InA, const T InB, int InId = -1)
     {
         if (any(InA != InB))
         {

--- a/test/Private/D3D12/Shader/HLSLTests.cpp
+++ b/test/Private/D3D12/Shader/HLSLTests.cpp
@@ -61,13 +61,13 @@ SCENARIO("HLSLTests")
                     std::tuple
                     {
                         "OperatorBool",
-                        [](const EHLSLVersion InVer) { return InVer == EHLSLVersion::v2021; },
+                        [](const EHLSLVersion InVer) { return InVer >= EHLSLVersion::v2021; },
                         std::vector<std::wstring>{}
                     },
                     std::tuple
                     {
                         "OperatorInt",
-                        [](const EHLSLVersion InVer) { return InVer == EHLSLVersion::v2021; },
+                        [](const EHLSLVersion InVer) { return InVer >= EHLSLVersion::v2021; },
                         std::vector<std::wstring>{}
                     },
                     std::tuple
@@ -97,7 +97,7 @@ SCENARIO("HLSLTests")
                     std::tuple
                     {
                         "StaticConstStructMemberInTemplatedStruct",
-                        [](const EHLSLVersion InVer) { return InVer == EHLSLVersion::v2021; },
+                        [](const EHLSLVersion InVer) { return InVer >= EHLSLVersion::v2021; },
                         std::vector<std::wstring>{}
                     },
                     std::tuple
@@ -163,25 +163,25 @@ SCENARIO("HLSLTests")
                     std::tuple
                     {
                         "ArrayTemplateSpecialization",
-                        [](const EHLSLVersion InVer) { return InVer == EHLSLVersion::v2021; },
+                        [](const EHLSLVersion InVer) { return InVer >= EHLSLVersion::v2021; },
                         std::vector<std::wstring>{}
                     },
                     std::tuple
                     {
                         "NestedStructTemplates",
-                        [](const EHLSLVersion InVer) { return InVer == EHLSLVersion::v2021; },
+                        [](const EHLSLVersion InVer) { return InVer >= EHLSLVersion::v2021; },
                         std::vector<std::wstring>{}
                     },
                     std::tuple
                     {
                         "TernaryInTypeTrait",
-                        [](const EHLSLVersion InVer) { return InVer == EHLSLVersion::v2021; },
+                        [](const EHLSLVersion InVer) { return InVer >= EHLSLVersion::v2021; },
                         std::vector<std::wstring>{}
                     },
                     std::tuple
                     {
                         "DeferSFINAE",
-                        [](const EHLSLVersion InVer) { return InVer == EHLSLVersion::v2021; },
+                        [](const EHLSLVersion InVer) { return InVer >= EHLSLVersion::v2021; },
                         std::vector<std::wstring>{}
                     },
                     std::tuple
@@ -199,7 +199,7 @@ SCENARIO("HLSLTests")
                     std::tuple
                     {
                         "CallOperator",
-                        [](const EHLSLVersion InVer) { return InVer == EHLSLVersion::v2021; },
+                        [](const EHLSLVersion InVer) { return InVer >= EHLSLVersion::v2021; },
                         std::vector<std::wstring>{}
                     },
                     std::tuple
@@ -270,7 +270,8 @@ SCENARIO("HLSLTests")
         EHLSLVersion::v2016,
         EHLSLVersion::v2017,
         EHLSLVersion::v2018,
-        EHLSLVersion::v2021
+        EHLSLVersion::v2021,
+        EHLSLVersion::v202x
     );
 
     auto compiler = CreateCompiler();

--- a/test/Private/D3D12/Shader/ShaderHashTests.cpp
+++ b/test/Private/D3D12/Shader/ShaderHashTests.cpp
@@ -14,20 +14,21 @@ SCENARIO("ShaderHashTests")
         job.ShaderModel = shaderModel;
         job.ShaderType = EShaderType::Compute;
         job.Source = std::string{ R"(
-                        RWBuffer<int64_t> Buff;
+                        RWBuffer<uint> Buff;
 
-                        int64_t InVal;
+                        uint InVal;
                         [numthreads(1,1,1)]
                         void Main(uint3 DispatchThreadId : SV_DispatchThreadID)
                         {
-                            Buff[DispatchThreadId.x] = (DispatchThreadId.x + 34) * InVal;
+                            Buff[DispatchThreadId.x] = (DispatchThreadId.x + 34u) * InVal;
                         }
                         )" };
         WHEN("compiled")
         {
             ShaderCompiler compiler;
             const auto result = compiler.CompileShader(job);
-
+            
+            CAPTURE(result);
             REQUIRE(result.has_value());
             
             THEN("Hash is valid")
@@ -55,13 +56,13 @@ SCENARIO("ShaderHashTests")
                 AND_WHEN("is compiled again with a slight change")
                 {
                     job.Source = std::string{ R"(
-                        RWBuffer<int64_t> Buff;
+                        RWBuffer<uint> Buff;
 
-                        int64_t InVal;
+                        uint InVal;
                         [numthreads(1,1,1)]
                         void Main(uint3 DispatchThreadId : SV_DispatchThreadID)
                         {
-                            Buff[DispatchThreadId.x] = (DispatchThreadId.x + 35) * InVal;
+                            Buff[DispatchThreadId.x] = (DispatchThreadId.x + 35u) * InVal;
                         }
                         )" };
 

--- a/test/Private/Framework/HLSLFramework/SectionHierarchyByteWriterTests.cpp
+++ b/test/Private/Framework/HLSLFramework/SectionHierarchyByteWriterTests.cpp
@@ -8,7 +8,6 @@ SCENARIO("HLSLFrameworkTests - SectionHierarchy - ByteWriter")
     ShaderTestFixture::Desc desc{};
 
     desc.Mappings.emplace_back(GetTestVirtualDirectoryMapping());
-    desc.HLSLVersion = EHLSLVersion::v2021;
     desc.Source = std::move(fs::path("/Tests/SectionHierarchyByteWriterTests.hlsl"));
     desc.GPUDeviceParams.DeviceType = GPUDevice::EDeviceType::Software;
     desc.TestDataLayout = STF::TestDataBufferLayout(100, 1024, 100, 6400, 100);

--- a/test/Private/Framework/HLSLFramework/SectionManagementTests.cpp
+++ b/test/Private/Framework/HLSLFramework/SectionManagementTests.cpp
@@ -16,7 +16,6 @@ SCENARIO("HLSLFrameworkTests - SectionManagement")
     ShaderTestFixture::Desc desc{};
 
     desc.Mappings.emplace_back(GetTestVirtualDirectoryMapping());
-    desc.HLSLVersion = EHLSLVersion::v2021;
     desc.Source = fs::path("/Tests/SectionManagement.hlsl");
     desc.GPUDeviceParams.DeviceType = GPUDevice::EDeviceType::Software;
     desc.TestDataLayout = STF::TestDataBufferLayout(100, 1024);

--- a/test/Private/Framework/HLSLFramework/TestDataBuffer/ResultsProcessing/SectionsWithStringsTests.cpp
+++ b/test/Private/Framework/HLSLFramework/TestDataBuffer/ResultsProcessing/SectionsWithStringsTests.cpp
@@ -221,7 +221,6 @@ SCENARIO("HLSLFrameworkTests - TestDataBuffer - ResultProcessing - SectionsWithS
     ShaderTestFixture::Desc desc{};
 
     desc.Mappings.emplace_back(GetTestVirtualDirectoryMapping());
-    desc.HLSLVersion = EHLSLVersion::v2021;
     desc.Source = fs::path("/Tests/TestDataBuffer/ResultsProcessing/SectionsWithStrings.hlsl");
     desc.GPUDeviceParams.DeviceType = GPUDevice::EDeviceType::Software;
     desc.TestDataLayout = STF::TestDataBufferLayout(100u, 10000u, 50u, 1000u, 50u);

--- a/test/Public/Framework/HLSLFramework/HLSLFrameworkTestsCommon.h
+++ b/test/Public/Framework/HLSLFramework/HLSLFrameworkTestsCommon.h
@@ -18,7 +18,6 @@ inline ShaderTestFixture::Desc CreateDescForHLSLFrameworkTest(fs::path&& InPath,
     ShaderTestFixture::Desc desc{};
 
     desc.Mappings.emplace_back(GetTestVirtualDirectoryMapping());
-    desc.HLSLVersion = EHLSLVersion::v2021;
     desc.Source = std::move(InPath);
     desc.GPUDeviceParams.DeviceType = GPUDevice::EDeviceType::Software;
     desc.TestDataLayout = InTestDataLayout;

--- a/test/Shader/D3D12/Shader/ShaderCompilerTests/HLSLTests/DeferSFINAE.hlsl
+++ b/test/Shader/D3D12/Shader/ShaderCompilerTests/HLSLTests/DeferSFINAE.hlsl
@@ -1,13 +1,13 @@
 template<typename T, T v>
-struct integral_constant
+struct my_integral_constant
 {
     static const T value = v;
     using value_type = T;
-    using type = integral_constant;
+    using type = my_integral_constant;
 };
 
-using true_type = integral_constant<bool, true>;
-using false_type = integral_constant<bool, false>;
+using true_type = my_integral_constant<bool, true>;
+using false_type = my_integral_constant<bool, false>;
 
 template<typename T, typename U>
 struct is_same : false_type

--- a/test/Shader/D3D12/Shader/ShaderCompilerTests/ShaderModelTests/ComputeShaderWith16BitFloats.hlsl
+++ b/test/Shader/D3D12/Shader/ShaderCompilerTests/ShaderModelTests/ComputeShaderWith16BitFloats.hlsl
@@ -1,4 +1,4 @@
-RWBuffer<float> Buff;
+RWBuffer<float16_t> Buff;
 
 float16_t InVal;
 [numthreads(1,1,1)]

--- a/test/Shader/D3D12/Shader/ShaderCompilerTests/ShaderModelTests/ComputeShaderWith64BitIntegers.hlsl
+++ b/test/Shader/D3D12/Shader/ShaderCompilerTests/ShaderModelTests/ComputeShaderWith64BitIntegers.hlsl
@@ -4,5 +4,5 @@ int64_t InVal;
 [numthreads(1,1,1)]
 void Main(uint3 DispatchThreadId : SV_DispatchThreadID)
 {
-    Buff[DispatchThreadId.x] = (DispatchThreadId.x + 34) * InVal;
+    Buff[DispatchThreadId.x] = 34 * InVal;
 }

--- a/test/Shader/D3D12/Shader/ShaderCompilerTests/ShaderModelTests/ComputeShaderWithDynamicResources.hlsl
+++ b/test/Shader/D3D12/Shader/ShaderCompilerTests/ShaderModelTests/ComputeShaderWithDynamicResources.hlsl
@@ -1,8 +1,8 @@
-int BuffIndex;
-int64_t InVal;
+uint BuffIndex;
+int InVal;
 [numthreads(1,1,1)]
 void Main(uint3 DispatchThreadId : SV_DispatchThreadID)
 {
-    RWBuffer<int64_t> Buff = ResourceDescriptorHeap[BuffIndex];
-    Buff[DispatchThreadId.x] = (DispatchThreadId.x + 34) * InVal;
+    RWBuffer<int> Buff = ResourceDescriptorHeap[BuffIndex];
+    Buff[DispatchThreadId.x] = 34 * InVal;
 }

--- a/test/Shader/HLSLFrameworkTests/ByteWriter/ByteWriterTests.hlsl
+++ b/test/Shader/HLSLFrameworkTests/ByteWriter/ByteWriterTests.hlsl
@@ -35,7 +35,7 @@ void GIVEN_FundamentalType_WHEN_BytesRequiredQueried_THEN_ExpectedNumberReturned
     STF::AreEqual(4u, ttl::bytes_required(3.4f));
     STF::AreEqual(8u, ttl::bytes_required(float2(1.0f, 2.0f)));
     STF::AreEqual(12u, ttl::bytes_required(float3(1.0f, 2.0f, 3.0f)));
-    STF::AreEqual(16u, ttl::bytes_required(float4(1.0f, 2.0f, 3.0f, 4.0f)));
+    STF::AreEqual(16u, ttl::bytes_required(float4(1.0l, 2.0l, 3.0l, 4.0l)));
 }
 
 [RootSignature(SHADER_TEST_RS)]
@@ -56,7 +56,7 @@ void GIVEN_FundamentalType_WHEN_AlignmentRequiredQueried_THEN_ExpectedNumberRetu
     STF::AreEqual(4u, ttl::alignment_required(float3(1.0f, 2.0f, 3.0f)));
     STF::AreEqual(4u, ttl::alignment_required(float4(1.0f, 2.0f, 3.0f, 4.0f)));
     STF::AreEqual(2u, ttl::alignment_required(float16_t4(1.0f, 2.0f, 3.0f, 4.0f)));
-    STF::AreEqual(8u, ttl::alignment_required(float64_t4(1.0f, 2.0f, 3.0f, 4.0f)));
+    STF::AreEqual(8u, ttl::alignment_required(float64_t4(1.0l, 2.0l, 3.0l, 4.0l)));
 }
 
 struct NoWriter

--- a/test/Shader/HLSLFrameworkTests/TestDataBuffer/ResultsProcessing/FundamentalByteReader.hlsl
+++ b/test/Shader/HLSLFrameworkTests/TestDataBuffer/ResultsProcessing/FundamentalByteReader.hlsl
@@ -53,7 +53,7 @@ void GIVEN_TwoScalarFloatingPoint16bit_WHEN_Failed_THEN_OutputHasExpectedSubstri
 [numthreads(1, 1, 1)]
 void GIVEN_TwoVector3FloatingPoint64bit_WHEN_Failed_THEN_OutputHasExpectedSubstrings()
 {
-    ASSERT(AreEqual, float64_t3(32.5, 32.5, 32.5), float64_t3(42.5, 42.5, 42.5));
+    ASSERT(AreEqual, float64_t3(32.5l, 32.5l, 32.5l), float64_t3(42.5l, 42.5l, 42.5l));
 }
 
 [RootSignature(SHADER_TEST_RS)]


### PR DESCRIPTION
Upgraded DXC to 1.8.2405.17
Updated to HLSL 202x
Fixed all things that broke with this upgrade:
1. Include path normalization
2. conversion warnings

Made use of the fact that literals are no longer their own types
Closes #85 