### PR TITLE
Updating docs

### DIFF
--- a/docs/TTL/TTL.md
+++ b/docs/TTL/TTL.md
@@ -4,12 +4,13 @@
 
 The Test Template Library (TTL) is analogous to the [C++ standard library](https://en.cppreference.com/w/cpp/header). It contains a collection of headers which are not dependent on the Shader Test Framework. It is a standalone library of templates and functions. It does depend on the following compiler flags to compile:
 
-- -HV 2021
+- -HV 202x
 - -enable-16bit-types
 
 ## HLSL and Library features
 
 - [Pseudo-concepts](./PseudoConcepts.md)
+- [_Static_assert](StaticAssert.md)
 
 ## Headers
 
@@ -20,5 +21,4 @@ The Test Template Library (TTL) is analogous to the [C++ standard library](https
 | [`container_wrapper.hlsli`](./ContainerWrapper.md) | class template for providing a unified interface around resource buffers and arrays |
 | [`macro.hlsli`](./Macro/MacroHeader.md) | library of utility function-like macros |
 | [`models.hlsli`](./Models/ModelsHeader.md) | Library for evaluating and constructing [pseudo-concepts](./PseudoConcepts.md) |
-| [`static_assert.hlsli`](./StaticAssert.md) | Macro for supply a `static_assert` like utility |
 | [`type_traits.hlsli`](./TypeTraits/TypeTraitsHeader.md) | Compile time type information |


### PR DESCRIPTION
Update docs to reflect that TTL requires 202x and moved the static_assert link out of the header section since that header no longer exists_