### PR TITLE
Changing Test and Validation badge

### DIFF
--- a/.github/workflows/PushWorkflow.yml
+++ b/.github/workflows/PushWorkflow.yml
@@ -1,4 +1,4 @@
-name: Push Workflow Checks
+name: Tests and Validation
 
 run-name: "${{github.actor}}: ${{ github.event.head_commit.message }}"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ShaderTestFramework
 
-![Tests](https://github.com/KStocky/ShaderTestFramework/actions/workflows/RWBuildAndRunTests.yml/badge.svg)
-![Link Validation](https://github.com/KStocky/ShaderTestFramework/actions/workflows/RWLinkValidation.yml/badge.svg)
+![Tests And Validation](https://github.com/KStocky/ShaderTestFramework/actions/workflows/PushWorkflow.yml/badge.svg)
 ![Minimum MSVC Version](https://byob.yarr.is/KStocky/ShaderTestFramework/MinMSVCVersion)
 ![Minimum CMake Version](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/KStocky/fc80ff760df6627ccc295d486a54824c/raw/MinCMakeVersion.json)
 


### PR DESCRIPTION
Since reusable workflows don't generate badges when they are ran from another workflow, switching the readme badges to just use the PushWorkflow badge