### PR TITLE
D3D12 Refactor

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SOURCES
     Public/Utility/Lambda.h
     Public/Utility/Math.h
     Public/Utility/MoveOnly.h
+    Public/Utility/Object.h
     Public/Utility/OverloadSet.h
     Public/Utility/Pointer.h
     Public/Utility/Time.h

--- a/src/Private/D3D12/CommandAllocator.cpp
+++ b/src/Private/D3D12/CommandAllocator.cpp
@@ -1,5 +1,7 @@
 #include "D3D12/CommandAllocator.h"
 
+#include "Utility/Exception.h"
+
 namespace stf
 {
     CommandAllocator::CommandAllocator(CreationParams InParams)
@@ -23,14 +25,8 @@ namespace stf
         return m_Type;
     }
 
-    ExpectedHRes<void> CommandAllocator::Reset()
+    void CommandAllocator::Reset()
     {
-        if (const auto hres = m_Allocator->Reset();
-            FAILED(hres))
-        {
-            return Unexpected(hres);
-        }
-
-        return {};
+        ThrowIfFailed(m_Allocator->Reset());
     }
 }

--- a/src/Private/D3D12/CommandEngine.cpp
+++ b/src/Private/D3D12/CommandEngine.cpp
@@ -12,6 +12,6 @@ namespace stf
 
     void CommandEngine::Flush()
     {
-        m_Queue.FlushQueue();
+        m_Queue->FlushQueue();
     }
 }

--- a/src/Private/D3D12/CommandList.cpp
+++ b/src/Private/D3D12/CommandList.cpp
@@ -19,7 +19,7 @@ namespace stf
     void CommandList::CopyBufferResource(GPUResource& InDest, GPUResource& InSource)
     {
         const auto prevSourceBarrier = InSource.GetBarrier();
-        const auto prevDestBarrier = InSource.GetBarrier();
+        const auto prevDestBarrier = InDest.GetBarrier();
 
         GPUEnhancedBarrier newSourceBarrier
         {
@@ -36,7 +36,7 @@ namespace stf
         };
 
         InSource.SetBarrier(newSourceBarrier);
-        InSource.SetBarrier(newDestBarrier);
+        InDest.SetBarrier(newDestBarrier);
 
         D3D12_BUFFER_BARRIER bufferBarriers[] =
         {
@@ -52,7 +52,7 @@ namespace stf
                 newDestBarrier.Sync,
                 prevDestBarrier.Access,
                 newDestBarrier.Access,
-                InSource
+                InDest
             )
         };
 

--- a/src/Private/D3D12/CommandList.cpp
+++ b/src/Private/D3D12/CommandList.cpp
@@ -128,7 +128,7 @@ namespace stf
 
     void CommandList::Reset(CommandAllocator& InAllocator)
     {
-        ThrowIfUnexpected(InAllocator.Reset());
+        InAllocator.Reset();
         ThrowIfFailed(m_List->Reset(InAllocator, nullptr));
     }
 

--- a/src/Private/D3D12/CommandQueue.cpp
+++ b/src/Private/D3D12/CommandQueue.cpp
@@ -12,25 +12,9 @@ namespace stf
     {
     }
 
-    CommandQueue::CommandQueue(CommandQueue&& In) noexcept
-        : m_Queue(std::move(In.m_Queue))
-        , m_Fence(std::move(In.m_Fence))
-    {
-    }
-
-    CommandQueue& CommandQueue::operator=(CommandQueue&& In) noexcept
-    {
-        m_Queue = std::move(In.m_Queue);
-        m_Fence = std::move(In.m_Fence);
-        return *this;
-    }
-
     CommandQueue::~CommandQueue()
     {
-        if (m_Queue)
-        {
-            FlushQueue();
-        }
+        FlushQueue();
     }
 
     bool CommandQueue::HasFencePointBeenReached(const Fence::FencePoint& InFencePoint) const
@@ -45,7 +29,7 @@ namespace stf
 
     void CommandQueue::WaitOnFence(const Fence::FencePoint& InFencePoint)
     {
-        ThrowIfUnexpected(m_Fence->WaitCPU(InFencePoint));
+        m_Fence->WaitCPU(InFencePoint);
     }
 
     void CommandQueue::SyncWithQueue(CommandQueue& InQueue)

--- a/src/Private/D3D12/CommandQueue.cpp
+++ b/src/Private/D3D12/CommandQueue.cpp
@@ -35,17 +35,17 @@ namespace stf
 
     bool CommandQueue::HasFencePointBeenReached(const Fence::FencePoint& InFencePoint) const
     {
-        return ThrowIfUnexpected(m_Fence.HasCompleted(InFencePoint));
+        return ThrowIfUnexpected(m_Fence->HasCompleted(InFencePoint));
     }
 
     Fence::FencePoint CommandQueue::Signal()
     {
-        return m_Fence.Signal(m_Queue.Get());
+        return m_Fence->Signal(m_Queue.Get());
     }
 
     void CommandQueue::WaitOnFence(const Fence::FencePoint& InFencePoint)
     {
-        ThrowIfUnexpected(m_Fence.WaitCPU(InFencePoint));
+        ThrowIfUnexpected(m_Fence->WaitCPU(InFencePoint));
     }
 
     void CommandQueue::SyncWithQueue(CommandQueue& InQueue)
@@ -77,7 +77,7 @@ namespace stf
 
     const Fence& CommandQueue::GetFence() const
     {
-        return m_Fence;
+        return *m_Fence;
     }
 
     D3D12_COMMAND_LIST_TYPE CommandQueue::GetType() const

--- a/src/Private/D3D12/Fence.cpp
+++ b/src/Private/D3D12/Fence.cpp
@@ -8,23 +8,6 @@ namespace stf
     {
     }
 
-    Fence::Fence(Fence&& In) noexcept
-        : m_Fence(std::exchange(In.m_Fence, nullptr))
-        , m_NextValue(std::exchange(In.m_NextValue, 0))
-    {
-    }
-
-    Fence& Fence::operator=(Fence&& In) noexcept
-    {
-        if (this != &In)
-        {
-            m_Fence = std::exchange(In.m_Fence, nullptr);
-            m_NextValue = std::exchange(In.m_NextValue, 0);
-        }
-
-        return *this;
-    }
-
     Fence::FencePoint Fence::Signal(ID3D12CommandQueue* InQueue)
     {
         InQueue->Signal(m_Fence.Get(), m_NextValue);

--- a/src/Private/D3D12/Fence.cpp
+++ b/src/Private/D3D12/Fence.cpp
@@ -14,11 +14,11 @@ namespace stf
         return { m_Fence.Get(), m_NextValue++ };
     }
 
-    Expected<void, bool> Fence::WaitCPU(const FencePoint& InFencePoint) const
+    bool Fence::WaitCPU(const FencePoint& InFencePoint) const
     {
         if (!Validate(InFencePoint))
         {
-            return Unexpected{ false };
+            return false;
         }
         const u64 currentValue = m_Fence->GetCompletedValue();
 
@@ -30,7 +30,7 @@ namespace stf
             WaitForSingleObject(event, INFINITE);
         }
 
-        return{};
+        return true;
     }
 
     void Fence::WaitOnQueue(ID3D12CommandQueue* InQueue) const

--- a/src/Private/D3D12/GPUDevice.cpp
+++ b/src/Private/D3D12/GPUDevice.cpp
@@ -225,14 +225,14 @@ namespace stf
         return MakeShared<GPUResource>(GPUResource::CreationParams{ std::move(raw), InClearValue ? std::optional{*InClearValue} : std::nullopt, {D3D12_BARRIER_SYNC_NONE, D3D12_BARRIER_ACCESS_NO_ACCESS, InInitialLayout} });
     }
 
-    DescriptorHeap GPUDevice::CreateDescriptorHeap(const D3D12_DESCRIPTOR_HEAP_DESC& InDesc, const std::string_view InName) const
+    SharedPtr<DescriptorHeap> GPUDevice::CreateDescriptorHeap(const D3D12_DESCRIPTOR_HEAP_DESC& InDesc, const std::string_view InName) const
     {
         ComPtr<ID3D12DescriptorHeap> heap = nullptr;
         ThrowIfFailed(m_Device->CreateDescriptorHeap(&InDesc, IID_PPV_ARGS(heap.GetAddressOf())));
 
         SetName(heap.Get(), InName);
         const u32 descriptorSize = GetDescriptorSize(InDesc.Type);
-        return DescriptorHeap(DescriptorHeap::Desc{ std::move(heap), descriptorSize });
+        return MakeShared<DescriptorHeap>(DescriptorHeap::Desc{ std::move(heap), descriptorSize });
     }
 
     Fence GPUDevice::CreateFence(const u64 InInitialValue, const std::string_view InName) const

--- a/src/Private/D3D12/GPUDevice.cpp
+++ b/src/Private/D3D12/GPUDevice.cpp
@@ -188,13 +188,13 @@ namespace stf
         return MakeShared<CommandAllocator>(CommandAllocator::CreationParams{ std::move(allocator), InType });
     }
 
-    CommandList GPUDevice::CreateCommandList(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName) const
+    SharedPtr<CommandList> GPUDevice::CreateCommandList(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName) const
     {
         ComPtr<ID3D12GraphicsCommandList9> list = nullptr;
 
         ThrowIfFailed(m_Device->CreateCommandList1(0, InType, D3D12_COMMAND_LIST_FLAG_NONE, IID_PPV_ARGS(list.GetAddressOf())));
         SetName(list.Get(), InName);
-        return CommandList(CommandList::CreationParams{ std::move(list) });
+        return MakeShared<CommandList>(CommandList::CreationParams{ std::move(list) });
     }
 
     CommandQueue GPUDevice::CreateCommandQueue(const D3D12_COMMAND_QUEUE_DESC& InDesc, const std::string_view InName) const

--- a/src/Private/D3D12/GPUDevice.cpp
+++ b/src/Private/D3D12/GPUDevice.cpp
@@ -205,7 +205,7 @@ namespace stf
         return CommandQueue(CommandQueue::CreationParams{ std::move(raw), std::move(CreateFence(0ull)) });
     }
 
-    GPUResource GPUDevice::CreateCommittedResource(const D3D12_HEAP_PROPERTIES& InHeapProps, const D3D12_HEAP_FLAGS InFlags, const D3D12_RESOURCE_DESC1& InResourceDesc, const D3D12_BARRIER_LAYOUT InInitialLayout, const D3D12_CLEAR_VALUE* InClearValue, const std::span<DXGI_FORMAT> InCastableFormats, const std::string_view InName) const
+    SharedPtr<GPUResource> GPUDevice::CreateCommittedResource(const D3D12_HEAP_PROPERTIES& InHeapProps, const D3D12_HEAP_FLAGS InFlags, const D3D12_RESOURCE_DESC1& InResourceDesc, const D3D12_BARRIER_LAYOUT InInitialLayout, const D3D12_CLEAR_VALUE* InClearValue, const std::span<DXGI_FORMAT> InCastableFormats, const std::string_view InName) const
     {
         ComPtr<ID3D12Resource2> raw{ nullptr };
 
@@ -222,7 +222,7 @@ namespace stf
                 IID_PPV_ARGS(raw.GetAddressOf()))
         );
         SetName(raw.Get(), InName);
-        return GPUResource(GPUResource::CreationParams{ std::move(raw), InClearValue ? std::optional{*InClearValue} : std::nullopt, {D3D12_BARRIER_SYNC_NONE, D3D12_BARRIER_ACCESS_NO_ACCESS, InInitialLayout} });
+        return MakeShared<GPUResource>(GPUResource::CreationParams{ std::move(raw), InClearValue ? std::optional{*InClearValue} : std::nullopt, {D3D12_BARRIER_SYNC_NONE, D3D12_BARRIER_ACCESS_NO_ACCESS, InInitialLayout} });
     }
 
     DescriptorHeap GPUDevice::CreateDescriptorHeap(const D3D12_DESCRIPTOR_HEAP_DESC& InDesc, const std::string_view InName) const

--- a/src/Private/D3D12/GPUDevice.cpp
+++ b/src/Private/D3D12/GPUDevice.cpp
@@ -154,22 +154,18 @@ namespace stf
 
     GPUDevice::~GPUDevice()
     {
-        const bool wasValid = IsValid();
-        const bool hasZeroRefs = m_Device.Reset() == 0;
 
-        if (wasValid && hasZeroRefs)
+        m_Device.Reset();
+        // Described in https://stackoverflow.com/questions/46802508/d3d12-unavoidable-leak-report
+        ComPtr<IDXGIDebug1> dxgiDebug;
+        if (SUCCEEDED(DXGIGetDebugInterface1(0, IID_PPV_ARGS(&dxgiDebug))))
         {
-            // Described in https://stackoverflow.com/questions/46802508/d3d12-unavoidable-leak-report
-            ComPtr<IDXGIDebug1> dxgiDebug;
-            if (SUCCEEDED(DXGIGetDebugInterface1(0, IID_PPV_ARGS(&dxgiDebug))))
-            {
-                dxgiDebug->ReportLiveObjects(DXGI_DEBUG_ALL, DXGI_DEBUG_RLO_FLAGS(DXGI_DEBUG_RLO_SUMMARY | DXGI_DEBUG_RLO_IGNORE_INTERNAL));
-            }
+            dxgiDebug->ReportLiveObjects(DXGI_DEBUG_ALL, DXGI_DEBUG_RLO_FLAGS(DXGI_DEBUG_RLO_SUMMARY | DXGI_DEBUG_RLO_IGNORE_INTERNAL));
+        }
 
-            if (m_PixHandle)
-            {
-                FreeLibrary(m_PixHandle);
-            }
+        if (m_PixHandle)
+        {
+            FreeLibrary(m_PixHandle);
         }
     }
 

--- a/src/Private/D3D12/GPUDevice.cpp
+++ b/src/Private/D3D12/GPUDevice.cpp
@@ -235,13 +235,13 @@ namespace stf
         return MakeShared<DescriptorHeap>(DescriptorHeap::Desc{ std::move(heap), descriptorSize });
     }
 
-    Fence GPUDevice::CreateFence(const u64 InInitialValue, const std::string_view InName) const
+    SharedPtr<Fence> GPUDevice::CreateFence(const u64 InInitialValue, const std::string_view InName) const
     {
         ComPtr<ID3D12Fence1> fence = nullptr;
 
         ThrowIfFailed(m_Device->CreateFence(InInitialValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(fence.GetAddressOf())));
         SetName(fence.Get(), InName);
-        return Fence(Fence::CreationParams{ std::move(fence), InInitialValue });
+        return MakeShared<Fence>(Fence::CreationParams{ std::move(fence), InInitialValue });
     }
 
     RootSignature GPUDevice::CreateRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC& InDesc) const

--- a/src/Private/D3D12/GPUDevice.cpp
+++ b/src/Private/D3D12/GPUDevice.cpp
@@ -179,13 +179,13 @@ namespace stf
         return m_PixHandle != nullptr;
     }
 
-    CommandAllocator GPUDevice::CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName) const
+    SharedPtr<CommandAllocator> GPUDevice::CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName) const
     {
         ComPtr<ID3D12CommandAllocator> allocator = nullptr;
 
         ThrowIfFailed(m_Device->CreateCommandAllocator(InType, IID_PPV_ARGS(allocator.GetAddressOf())));
         SetName(allocator.Get(), InName);
-        return CommandAllocator(CommandAllocator::CreationParams{ std::move(allocator), InType });
+        return MakeShared<CommandAllocator>(CommandAllocator::CreationParams{ std::move(allocator), InType });
     }
 
     CommandList GPUDevice::CreateCommandList(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName) const

--- a/src/Private/D3D12/GPUDevice.cpp
+++ b/src/Private/D3D12/GPUDevice.cpp
@@ -197,12 +197,12 @@ namespace stf
         return MakeShared<CommandList>(CommandList::CreationParams{ std::move(list) });
     }
 
-    CommandQueue GPUDevice::CreateCommandQueue(const D3D12_COMMAND_QUEUE_DESC& InDesc, const std::string_view InName) const
+    SharedPtr<CommandQueue> GPUDevice::CreateCommandQueue(const D3D12_COMMAND_QUEUE_DESC& InDesc, const std::string_view InName) const
     {
         ComPtr<ID3D12CommandQueue> raw = nullptr;
         ThrowIfFailed(m_Device->CreateCommandQueue(&InDesc, IID_PPV_ARGS(raw.GetAddressOf())));
         SetName(raw.Get(), InName);
-        return CommandQueue(CommandQueue::CreationParams{ std::move(raw), std::move(CreateFence(0ull)) });
+        return MakeShared<CommandQueue>(CommandQueue::CreationParams{ std::move(raw), std::move(CreateFence(0ull)) });
     }
 
     SharedPtr<GPUResource> GPUDevice::CreateCommittedResource(const D3D12_HEAP_PROPERTIES& InHeapProps, const D3D12_HEAP_FLAGS InFlags, const D3D12_RESOURCE_DESC1& InResourceDesc, const D3D12_BARRIER_LAYOUT InInitialLayout, const D3D12_CLEAR_VALUE* InClearValue, const std::span<DXGI_FORMAT> InCastableFormats, const std::string_view InName) const

--- a/src/Private/D3D12/GPUDevice.cpp
+++ b/src/Private/D3D12/GPUDevice.cpp
@@ -244,7 +244,7 @@ namespace stf
         return MakeShared<Fence>(Fence::CreationParams{ std::move(fence), InInitialValue });
     }
 
-    RootSignature GPUDevice::CreateRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC& InDesc) const
+    SharedPtr<RootSignature> GPUDevice::CreateRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC& InDesc) const
     {
         ComPtr<ID3DBlob> signature;
         ComPtr<ID3DBlob> error;
@@ -255,10 +255,10 @@ namespace stf
 
         ComPtr<ID3D12VersionedRootSignatureDeserializer> deserializer;
         ThrowIfFailed(D3D12CreateVersionedRootSignatureDeserializer(signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(deserializer.GetAddressOf())));
-        return RootSignature(RootSignature::CreationParams{ std::move(rootSignatureObject), std::move(deserializer), std::move(signature) });
+        return MakeShared<RootSignature>(RootSignature::CreationParams{ std::move(rootSignatureObject), std::move(deserializer), std::move(signature) });
     }
 
-    RootSignature GPUDevice::CreateRootSignature(const CompiledShaderData& InShader) const
+    SharedPtr<RootSignature> GPUDevice::CreateRootSignature(const CompiledShaderData& InShader) const
     {
         ComPtr<ID3D12RootSignature> rootSignatureObject;
         const auto codeBlob = InShader.GetCompiledShader();

--- a/src/Private/Framework/ShaderTestFixture.cpp
+++ b/src/Private/Framework/ShaderTestFixture.cpp
@@ -36,7 +36,7 @@ namespace stf
     std::vector<TimedStat> ShaderTestFixture::cachedStats;
 
     ShaderTestFixture::ShaderTestFixture(FixtureDesc InParams)
-        : m_Device(InParams.GPUDeviceParams)
+        : m_Device(MakeShared<GPUDevice>(InParams.GPUDeviceParams))
         , m_Compiler(CreateShaderCompiler(std::move(InParams.Mappings)))
         , m_ByteReaderMap()
         , m_Defines()
@@ -98,7 +98,7 @@ namespace stf
 
     bool ShaderTestFixture::IsValid() const
     {
-        return m_Device.IsValid();
+        return m_Device->IsValid();
     }
 
     bool ShaderTestFixture::IsUsingAgilitySDK() const
@@ -108,7 +108,7 @@ namespace stf
             return false;
         }
 
-        return m_Device.GetHardwareInfo().FeatureInfo.EnhancedBarriersSupport;
+        return m_Device->GetHardwareInfo().FeatureInfo.EnhancedBarriersSupport;
     }
 
     std::vector<TimedStat> ShaderTestFixture::GetTestStats()
@@ -282,13 +282,13 @@ namespace stf
 
     CommandEngine ShaderTestFixture::CreateCommandEngine() const
     {
-        auto commandList = m_Device.CreateCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
+        auto commandList = m_Device->CreateCommandList(D3D12_COMMAND_LIST_TYPE_DIRECT);
         D3D12_COMMAND_QUEUE_DESC queueDesc;
         queueDesc.NodeMask = 0;
         queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
         queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
         queueDesc.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
-        auto commandQueue = m_Device.CreateCommandQueue(queueDesc);
+        auto commandQueue = m_Device->CreateCommandQueue(queueDesc);
 
         return CommandEngine(CommandEngine::CreationParams{ std::move(commandList), std::move(commandQueue), m_Device });
     }
@@ -317,7 +317,7 @@ namespace stf
         desc.NodeMask = 0;
         desc.NumDescriptors = 2;
         desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        return m_Device.CreateDescriptorHeap(desc);
+        return m_Device->CreateDescriptorHeap(desc);
     }
 
     PipelineState ShaderTestFixture::CreatePipelineState(const RootSignature& InRootSig, IDxcBlob* InShader) const
@@ -330,7 +330,7 @@ namespace stf
         desc.Flags = D3D12_PIPELINE_STATE_FLAG_NONE;
         desc.NodeMask = 0;
         desc.pRootSignature = InRootSig;
-        return m_Device.CreatePipelineState(desc);
+        return m_Device->CreatePipelineState(desc);
     }
 
     Expected<ShaderTestFixture::ReflectionResults, ErrorTypeAndDescription> ShaderTestFixture::ProcessShaderReflection(const CompiledShaderData& InShaderData) const
@@ -441,7 +441,7 @@ namespace stf
         );
 
         return ReflectionResults{ 
-            .RootSig = m_Device.CreateRootSignature(rootSig), 
+            .RootSig = m_Device->CreateRootSignature(rootSig), 
             .NameToBindingInfo = std::move(nameToBindingInfo),
             .RootParamBuffers = std::move(rootParamBuffers)
         };
@@ -490,14 +490,14 @@ namespace stf
         const auto heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
         const auto resourceDesc = CD3DX12_RESOURCE_DESC1::Buffer(InSizeInBytes, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
 
-        return m_Device.CreateCommittedResource(heapProps, D3D12_HEAP_FLAG_NONE, resourceDesc, D3D12_BARRIER_LAYOUT_UNDEFINED);
+        return m_Device->CreateCommittedResource(heapProps, D3D12_HEAP_FLAG_NONE, resourceDesc, D3D12_BARRIER_LAYOUT_UNDEFINED);
     }
 
     GPUResource ShaderTestFixture::CreateReadbackBuffer(const u64 InSizeInBytes) const
     {
         const auto heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK);
         const auto resourceDesc = CD3DX12_RESOURCE_DESC1::Buffer(InSizeInBytes);
-        return m_Device.CreateCommittedResource(heapProps, D3D12_HEAP_FLAG_NONE, resourceDesc, D3D12_BARRIER_LAYOUT_UNDEFINED);
+        return m_Device->CreateCommittedResource(heapProps, D3D12_HEAP_FLAG_NONE, resourceDesc, D3D12_BARRIER_LAYOUT_UNDEFINED);
     }
 
     DescriptorHandle ShaderTestFixture::CreateAssertBufferUAV(const GPUResource& InAssertBuffer, const DescriptorHeap& InHeap, const u32 InIndex) const
@@ -511,7 +511,7 @@ namespace stf
         uavDesc.Buffer.StructureByteStride = 0;
         uavDesc.Format = DXGI_FORMAT_R32_TYPELESS;
         uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-        m_Device.CreateUnorderedAccessView(InAssertBuffer, uavDesc, uav);
+        m_Device->CreateUnorderedAccessView(InAssertBuffer, uavDesc, uav);
         return uav;
     }
 
@@ -728,7 +728,7 @@ namespace stf
     bool ShaderTestFixture::ShouldTakeCapture(const EGPUCaptureMode InCaptureMode, const bool InIsFailureRetry) const
     {
         const bool takeCaptureIfAble = InCaptureMode == EGPUCaptureMode::On || (InIsFailureRetry && InCaptureMode == EGPUCaptureMode::CaptureOnFailure);
-        return m_Device.IsGPUCaptureEnabled() && takeCaptureIfAble;
+        return m_Device->IsGPUCaptureEnabled() && takeCaptureIfAble;
     }
 }
 

--- a/src/Private/Framework/ShaderTestFixture.cpp
+++ b/src/Private/Framework/ShaderTestFixture.cpp
@@ -192,8 +192,8 @@ namespace stf
         auto readBackBuffer = CreateReadbackBuffer(bufferSizeInBytes);
         auto readBackAllocationBuffer = CreateReadbackBuffer(28ull);
 
-        const auto assertUAV = CreateAssertBufferUAV(assertBuffer, resourceHeap, 0);
-        const auto allocationUAV = CreateAssertBufferUAV(allocationBuffer, resourceHeap, 1);
+        const auto assertUAV = CreateAssertBufferUAV(*assertBuffer, resourceHeap, 0);
+        const auto allocationUAV = CreateAssertBufferUAV(*allocationBuffer, resourceHeap, 1);
 
         {
             ScopedDuration testExecution("ShaderTestFixture::RunTest Test Execution");
@@ -217,8 +217,8 @@ namespace stf
                             InContext->SetPipelineState(pipelineState);
                             InContext->SetDescriptorHeaps(resourceHeap);
                             InContext->SetComputeRootSignature(reflectionData.value().RootSig);
-                            InContext->SetBufferUAV(assertBuffer);
-                            InContext->SetBufferUAV(allocationBuffer);
+                            InContext->SetBufferUAV(*assertBuffer);
+                            InContext->SetBufferUAV(*allocationBuffer);
 
                             for (const auto& [paramIndex, buffer] : reflectionData.value().RootParamBuffers)
                             {
@@ -237,8 +237,8 @@ namespace stf
                     InContext.Section("Results readback",
                         [&](ScopedCommandContext& InContext)
                         {
-                            InContext->CopyBufferResource(readBackBuffer, assertBuffer);
-                            InContext->CopyBufferResource(readBackAllocationBuffer, allocationBuffer);
+                            InContext->CopyBufferResource(*readBackBuffer, *assertBuffer);
+                            InContext->CopyBufferResource(*readBackAllocationBuffer, *allocationBuffer);
                         }
                     );
                 }
@@ -249,7 +249,7 @@ namespace stf
 
         {
             ScopedDuration readbackScope(std::format("ShaderTestFixture::ReadbackResults: {}", InTestDesc.TestName));
-            return ReadbackResults(readBackAllocationBuffer, readBackBuffer, uint3(dimX, dimY, dimZ), testDataLayout);
+            return ReadbackResults(*readBackAllocationBuffer, *readBackBuffer, uint3(dimX, dimY, dimZ), testDataLayout);
         }
     }
 
@@ -485,7 +485,7 @@ namespace stf
         return {};
     }
 
-    GPUResource ShaderTestFixture::CreateAssertBuffer(const u64 InSizeInBytes) const
+    SharedPtr<GPUResource> ShaderTestFixture::CreateAssertBuffer(const u64 InSizeInBytes) const
     {
         const auto heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
         const auto resourceDesc = CD3DX12_RESOURCE_DESC1::Buffer(InSizeInBytes, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
@@ -493,7 +493,7 @@ namespace stf
         return m_Device->CreateCommittedResource(heapProps, D3D12_HEAP_FLAG_NONE, resourceDesc, D3D12_BARRIER_LAYOUT_UNDEFINED);
     }
 
-    GPUResource ShaderTestFixture::CreateReadbackBuffer(const u64 InSizeInBytes) const
+    SharedPtr<GPUResource> ShaderTestFixture::CreateReadbackBuffer(const u64 InSizeInBytes) const
     {
         const auto heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK);
         const auto resourceDesc = CD3DX12_RESOURCE_DESC1::Buffer(InSizeInBytes);

--- a/src/Private/Framework/ShaderTestFixture.cpp
+++ b/src/Private/Framework/ShaderTestFixture.cpp
@@ -148,7 +148,7 @@ namespace stf
         {
             return Results{ reflectionData.error() };
         }
-        auto pipelineState = CreatePipelineState(reflectionData.value().RootSig, compileResult->GetCompiledShader());
+        auto pipelineState = CreatePipelineState(*reflectionData.value().RootSig, compileResult->GetCompiledShader());
 
         const auto [dimX, dimY, dimZ] =
             [&compileResult, threadGroupCount = InTestDesc.ThreadGroupCount]()
@@ -216,7 +216,7 @@ namespace stf
                         {
                             InContext->SetPipelineState(*pipelineState);
                             InContext->SetDescriptorHeaps(*resourceHeap);
-                            InContext->SetComputeRootSignature(reflectionData.value().RootSig);
+                            InContext->SetComputeRootSignature(*reflectionData.value().RootSig);
                             InContext->SetBufferUAV(*assertBuffer);
                             InContext->SetBufferUAV(*allocationBuffer);
 

--- a/src/Private/Framework/ShaderTestFixture.cpp
+++ b/src/Private/Framework/ShaderTestFixture.cpp
@@ -192,8 +192,8 @@ namespace stf
         auto readBackBuffer = CreateReadbackBuffer(bufferSizeInBytes);
         auto readBackAllocationBuffer = CreateReadbackBuffer(28ull);
 
-        const auto assertUAV = CreateAssertBufferUAV(*assertBuffer, resourceHeap, 0);
-        const auto allocationUAV = CreateAssertBufferUAV(*allocationBuffer, resourceHeap, 1);
+        const auto assertUAV = CreateAssertBufferUAV(*assertBuffer, *resourceHeap, 0);
+        const auto allocationUAV = CreateAssertBufferUAV(*allocationBuffer, *resourceHeap, 1);
 
         {
             ScopedDuration testExecution("ShaderTestFixture::RunTest Test Execution");
@@ -215,7 +215,7 @@ namespace stf
                         [&](ScopedCommandContext& InContext)
                         {
                             InContext->SetPipelineState(pipelineState);
-                            InContext->SetDescriptorHeaps(resourceHeap);
+                            InContext->SetDescriptorHeaps(*resourceHeap);
                             InContext->SetComputeRootSignature(reflectionData.value().RootSig);
                             InContext->SetBufferUAV(*assertBuffer);
                             InContext->SetBufferUAV(*allocationBuffer);
@@ -310,7 +310,7 @@ namespace stf
         );
     }
 
-    DescriptorHeap ShaderTestFixture::CreateDescriptorHeap() const
+    SharedPtr<DescriptorHeap> ShaderTestFixture::CreateDescriptorHeap() const
     {
         D3D12_DESCRIPTOR_HEAP_DESC desc;
         desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;

--- a/src/Private/Framework/ShaderTestFixture.cpp
+++ b/src/Private/Framework/ShaderTestFixture.cpp
@@ -214,7 +214,7 @@ namespace stf
                     InContext.Section("Test Setup",
                         [&](ScopedCommandContext& InContext)
                         {
-                            InContext->SetPipelineState(pipelineState);
+                            InContext->SetPipelineState(*pipelineState);
                             InContext->SetDescriptorHeaps(*resourceHeap);
                             InContext->SetComputeRootSignature(reflectionData.value().RootSig);
                             InContext->SetBufferUAV(*assertBuffer);
@@ -320,7 +320,7 @@ namespace stf
         return m_Device->CreateDescriptorHeap(desc);
     }
 
-    PipelineState ShaderTestFixture::CreatePipelineState(const RootSignature& InRootSig, IDxcBlob* InShader) const
+    SharedPtr<PipelineState> ShaderTestFixture::CreatePipelineState(const RootSignature& InRootSig, IDxcBlob* InShader) const
     {
         D3D12_COMPUTE_PIPELINE_STATE_DESC desc;
         desc.CachedPSO.CachedBlobSizeInBytes = 0;

--- a/src/Public/D3D12/CommandAllocator.h
+++ b/src/Public/D3D12/CommandAllocator.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include "Platform.h"
-#include "Utility/MoveOnly.h"
+#include "Utility/Object.h"
 #include "Utility/Pointer.h"
 
 #include <d3d12.h>
 
 namespace stf
 {
-    class CommandAllocator : MoveOnly
+    class CommandAllocator : Object
     {
     public:
 
@@ -25,7 +25,7 @@ namespace stf
 
         D3D12_COMMAND_LIST_TYPE GetType() const;
 
-        ExpectedHRes<void> Reset();
+        void Reset();
 
     private:
 

--- a/src/Public/D3D12/CommandEngine.h
+++ b/src/Public/D3D12/CommandEngine.h
@@ -114,7 +114,7 @@ namespace stf
                     return std::move(ThrowIfUnexpected(m_Allocators.pop_front()).Allocator);
                 }();
 
-            m_List.Reset(allocator);
+            m_List.Reset(*allocator);
             ScopedCommandContext context(CommandEngineToken{}, &m_List);
             InFunc(context);
 
@@ -141,7 +141,7 @@ namespace stf
 
         struct FencedAllocator
         {
-            CommandAllocator Allocator;
+            SharedPtr<CommandAllocator> Allocator;
             Fence::FencePoint FencePoint;
         };
 

--- a/src/Public/D3D12/CommandEngine.h
+++ b/src/Public/D3D12/CommandEngine.h
@@ -64,7 +64,7 @@ namespace stf
 
         struct CreationParams
         {
-            CommandList List;
+            SharedPtr<CommandList> List;
             CommandQueue Queue;
             SharedPtr<GPUDevice> Device;
         };
@@ -89,12 +89,12 @@ namespace stf
                     return std::move(ThrowIfUnexpected(m_Allocators.pop_front()).Allocator);
                 }();
 
-            m_List.Reset(allocator);
-            ScopedCommandContext context(CommandEngineToken{}, &m_List);
+            m_List->Reset(allocator);
+            ScopedCommandContext context(CommandEngineToken{}, m_List.get());
             InFunc(context);
 
             m_Allocators.push_back(FencedAllocator{ std::move(allocator), m_Queue.Signal() });
-            m_Queue.ExecuteCommandList(m_List);
+            m_Queue.ExecuteCommandList(*m_List);
         }
 
         template<ExecuteLambdaType InLambdaType>
@@ -114,12 +114,12 @@ namespace stf
                     return std::move(ThrowIfUnexpected(m_Allocators.pop_front()).Allocator);
                 }();
 
-            m_List.Reset(*allocator);
-            ScopedCommandContext context(CommandEngineToken{}, &m_List);
+            m_List->Reset(*allocator);
+            ScopedCommandContext context(CommandEngineToken{}, m_List.get());
             InFunc(context);
 
             m_Allocators.push_back(FencedAllocator{ std::move(allocator), m_Queue.Signal() });
-            m_Queue.ExecuteCommandList(m_List);
+            m_Queue.ExecuteCommandList(*m_List);
         }
 
         template<ExecuteLambdaType InLambdaType>
@@ -147,7 +147,7 @@ namespace stf
 
         SharedPtr<GPUDevice> m_Device;
         CommandQueue m_Queue;
-        CommandList m_List;
+        SharedPtr<CommandList> m_List;
         RingBuffer<FencedAllocator> m_Allocators;
     };
 }

--- a/src/Public/D3D12/CommandEngine.h
+++ b/src/Public/D3D12/CommandEngine.h
@@ -7,6 +7,7 @@
 
 #include "Utility/FunctionTraits.h"
 #include "Utility/Lambda.h"
+#include "Utility/Pointer.h"
 
 #include <WinPixEventRuntime/pix3.h>
 
@@ -65,7 +66,7 @@ namespace stf
         {
             CommandList List;
             CommandQueue Queue;
-            GPUDevice Device;
+            SharedPtr<GPUDevice> Device;
         };
 
         CommandEngine() = default;
@@ -78,7 +79,7 @@ namespace stf
                 {
                     if (m_Allocators.size() == 0 || !m_Queue.HasFencePointBeenReached(m_Allocators.front().FencePoint))
                     {
-                        return m_Device.CreateCommandAllocator
+                        return m_Device->CreateCommandAllocator
                         (
                             D3D12_COMMAND_LIST_TYPE_DIRECT,
                             "Command Allocator"
@@ -103,7 +104,7 @@ namespace stf
                 {
                     if (m_Allocators.size() == 0 || !m_Queue.HasFencePointBeenReached(m_Allocators.front().FencePoint))
                     {
-                        return m_Device.CreateCommandAllocator
+                        return m_Device->CreateCommandAllocator
                         (
                             D3D12_COMMAND_LIST_TYPE_DIRECT,
                             "Command Allocator"
@@ -144,7 +145,7 @@ namespace stf
             Fence::FencePoint FencePoint;
         };
 
-        GPUDevice m_Device;
+        SharedPtr<GPUDevice> m_Device;
         CommandQueue m_Queue;
         CommandList m_List;
         RingBuffer<FencedAllocator> m_Allocators;

--- a/src/Public/D3D12/CommandList.h
+++ b/src/Public/D3D12/CommandList.h
@@ -1,8 +1,8 @@
 #pragma once
-
-#include "Utility/MoveOnly.h"
 #include "Platform.h"
 #include "Utility/Concepts.h"
+
+#include "Utility/Object.h"
 #include "Utility/Pointer.h"
 
 #include <bit>
@@ -21,7 +21,7 @@ namespace stf
     template<typename T>
     concept RootSigConstantType = std::is_trivial_v<T> && sizeof(T) == 4;
 
-    class CommandList : MoveOnly
+    class CommandList : Object
     {
     public:
 

--- a/src/Public/D3D12/CommandQueue.h
+++ b/src/Public/D3D12/CommandQueue.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "D3D12/Fence.h"
-#include "Utility/MoveOnly.h"
+#include "Utility/Object.h"
 #include "Utility/Pointer.h"
 
 #include <d3d12.h>
@@ -10,7 +10,7 @@ namespace stf
 {
     class CommandList;
 
-    class CommandQueue : MoveOnly
+    class CommandQueue : Object
     {
     public:
 
@@ -22,8 +22,6 @@ namespace stf
 
         CommandQueue() = default;
         CommandQueue(CreationParams InParams);
-        CommandQueue(CommandQueue&& In) noexcept;
-        CommandQueue& operator=(CommandQueue&& In) noexcept;
         ~CommandQueue();
 
         bool HasFencePointBeenReached(const Fence::FencePoint& InFencePoint) const;

--- a/src/Public/D3D12/CommandQueue.h
+++ b/src/Public/D3D12/CommandQueue.h
@@ -17,7 +17,7 @@ namespace stf
         struct CreationParams
         {
             ComPtr<ID3D12CommandQueue> Queue;
-            Fence Fence{};
+            SharedPtr<Fence> Fence{};
         };
 
         CommandQueue() = default;
@@ -43,6 +43,6 @@ namespace stf
     private:
 
         ComPtr<ID3D12CommandQueue> m_Queue = nullptr;
-        Fence m_Fence;
+        SharedPtr<Fence> m_Fence = nullptr;
     };
 }

--- a/src/Public/D3D12/DescriptorHeap.h
+++ b/src/Public/D3D12/DescriptorHeap.h
@@ -1,16 +1,16 @@
 #pragma once
 
+#include "Platform.h"
 #include "D3D12/Descriptor.h"
 #include "Utility/Expected.h"
-#include "Utility/MoveOnly.h"
-#include "Platform.h"
+#include "Utility/Object.h"
 #include "Utility/Pointer.h"
 
 #include <d3d12.h>
 
 namespace stf
 {
-    class DescriptorHeap : MoveOnly
+    class DescriptorHeap : Object
     {
     public:
 
@@ -38,16 +38,14 @@ namespace stf
         D3D12_DESCRIPTOR_HEAP_TYPE GetType() const noexcept;
         D3D12_DESCRIPTOR_HEAP_FLAGS GetAccess() const;
 
-        template<typename ThisType>
-        ID3D12DescriptorHeap* GetRaw(this ThisType&& InThis)
+        ID3D12DescriptorHeap* GetRaw() const
         {
-            return std::forward<ThisType>(InThis).m_Heap.Get();
+            return m_Heap.Get();
         }
 
-        template<typename ThisType>
-        operator ID3D12DescriptorHeap* (this ThisType&& InThis)
+        operator ID3D12DescriptorHeap*() const
         {
-            return std::forward<ThisType>(InThis).GetRaw();
+            return GetRaw();
         }
 
     private:

--- a/src/Public/D3D12/Fence.h
+++ b/src/Public/D3D12/Fence.h
@@ -38,7 +38,7 @@ namespace stf
         Fence(CreationParams InParams);
 
         [[nodiscard]] FencePoint Signal(ID3D12CommandQueue* InQueue);
-        Expected<void, bool> WaitCPU(const FencePoint& InFencePoint) const;
+        bool WaitCPU(const FencePoint& InFencePoint) const;
         void WaitOnQueue(ID3D12CommandQueue* InQueue) const;
         Expected<bool, bool> HasCompleted(const FencePoint& InFencePoint) const;
 

--- a/src/Public/D3D12/Fence.h
+++ b/src/Public/D3D12/Fence.h
@@ -1,13 +1,14 @@
 #pragma once
-#include "Utility/MoveOnly.h"
 #include "Platform.h"
+
+#include "Utility/Object.h"
 #include "Utility/Pointer.h"
 
 #include <d3d12.h>
 
 namespace stf
 {
-    class Fence : MoveOnly
+    class Fence : Object
     {
     public:
 
@@ -35,9 +36,6 @@ namespace stf
 
         Fence() = default;
         Fence(CreationParams InParams);
-        Fence(Fence&& In) noexcept;
-
-        Fence& operator=(Fence&& In) noexcept;
 
         [[nodiscard]] FencePoint Signal(ID3D12CommandQueue* InQueue);
         Expected<void, bool> WaitCPU(const FencePoint& InFencePoint) const;

--- a/src/Public/D3D12/GPUDevice.h
+++ b/src/Public/D3D12/GPUDevice.h
@@ -136,7 +136,7 @@ namespace stf
         bool IsValid() const;
         bool IsGPUCaptureEnabled() const;
 
-        CommandAllocator CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName = "DefaultCommandAllocator") const;
+        SharedPtr<CommandAllocator> CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName = "DefaultCommandAllocator") const;
         CommandList CreateCommandList(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName = "DefaultCommandList") const;
         CommandQueue CreateCommandQueue(const D3D12_COMMAND_QUEUE_DESC& InDesc, const std::string_view InName = "DefaultCommandQueue") const;
 

--- a/src/Public/D3D12/GPUDevice.h
+++ b/src/Public/D3D12/GPUDevice.h
@@ -138,7 +138,7 @@ namespace stf
 
         SharedPtr<CommandAllocator> CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName = "DefaultCommandAllocator") const;
         SharedPtr<CommandList> CreateCommandList(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName = "DefaultCommandList") const;
-        CommandQueue CreateCommandQueue(const D3D12_COMMAND_QUEUE_DESC& InDesc, const std::string_view InName = "DefaultCommandQueue") const;
+        SharedPtr<CommandQueue> CreateCommandQueue(const D3D12_COMMAND_QUEUE_DESC& InDesc, const std::string_view InName = "DefaultCommandQueue") const;
 
         SharedPtr<GPUResource> CreateCommittedResource(
             const D3D12_HEAP_PROPERTIES& InHeapProps,

--- a/src/Public/D3D12/GPUDevice.h
+++ b/src/Public/D3D12/GPUDevice.h
@@ -137,7 +137,7 @@ namespace stf
         bool IsGPUCaptureEnabled() const;
 
         SharedPtr<CommandAllocator> CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName = "DefaultCommandAllocator") const;
-        CommandList CreateCommandList(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName = "DefaultCommandList") const;
+        SharedPtr<CommandList> CreateCommandList(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName = "DefaultCommandList") const;
         CommandQueue CreateCommandQueue(const D3D12_COMMAND_QUEUE_DESC& InDesc, const std::string_view InName = "DefaultCommandQueue") const;
 
         SharedPtr<GPUResource> CreateCommittedResource(

--- a/src/Public/D3D12/GPUDevice.h
+++ b/src/Public/D3D12/GPUDevice.h
@@ -11,6 +11,7 @@
 #include "D3D12/Shader/RootSignature.h"
 #include "Platform.h"
 #include "Utility/Exception.h"
+#include "Utility/Object.h"
 #include "Utility/Pointer.h"
 
 #include <span>
@@ -104,7 +105,7 @@ namespace stf
         std::is_same_v<T, D3D12_COMPUTE_PIPELINE_STATE_DESC> ||
         std::is_same_v<T, D3DX12_MESH_SHADER_PIPELINE_STATE_DESC>;
 
-    class GPUDevice
+    class GPUDevice : Object
     {
     public:
 
@@ -130,10 +131,6 @@ namespace stf
 
         GPUDevice() = default;
         GPUDevice(const CreationParams InDesc);
-        GPUDevice(const GPUDevice&) = default;
-        GPUDevice(GPUDevice&&) = default;
-        GPUDevice& operator=(const GPUDevice&) = default;
-        GPUDevice& operator=(GPUDevice&&) = default;
         ~GPUDevice();
 
         bool IsValid() const;

--- a/src/Public/D3D12/GPUDevice.h
+++ b/src/Public/D3D12/GPUDevice.h
@@ -149,7 +149,8 @@ namespace stf
             const std::span<DXGI_FORMAT> InCastableFormats = {},
             const std::string_view InName = "DefaultResource"
         ) const;
-        DescriptorHeap CreateDescriptorHeap(const D3D12_DESCRIPTOR_HEAP_DESC& InDesc, const std::string_view InName = "DefaultDescriptorHeap") const;
+
+        SharedPtr<DescriptorHeap> CreateDescriptorHeap(const D3D12_DESCRIPTOR_HEAP_DESC& InDesc, const std::string_view InName = "DefaultDescriptorHeap") const;
 
         Fence CreateFence(const u64 InInitialValue, const std::string_view InName = "DefaultFence") const;
 

--- a/src/Public/D3D12/GPUDevice.h
+++ b/src/Public/D3D12/GPUDevice.h
@@ -152,7 +152,7 @@ namespace stf
 
         SharedPtr<DescriptorHeap> CreateDescriptorHeap(const D3D12_DESCRIPTOR_HEAP_DESC& InDesc, const std::string_view InName = "DefaultDescriptorHeap") const;
 
-        Fence CreateFence(const u64 InInitialValue, const std::string_view InName = "DefaultFence") const;
+        SharedPtr<Fence> CreateFence(const u64 InInitialValue, const std::string_view InName = "DefaultFence") const;
 
         template<PipelineStateDescType T>
         PipelineState CreatePipelineState(const T& InDesc) const

--- a/src/Public/D3D12/GPUDevice.h
+++ b/src/Public/D3D12/GPUDevice.h
@@ -155,7 +155,7 @@ namespace stf
         SharedPtr<Fence> CreateFence(const u64 InInitialValue, const std::string_view InName = "DefaultFence") const;
 
         template<PipelineStateDescType T>
-        PipelineState CreatePipelineState(const T& InDesc) const
+        SharedPtr<PipelineState> CreatePipelineState(const T& InDesc) const
         {
             CD3DX12_PIPELINE_STATE_STREAM5 rawStream(InDesc);
             const D3D12_PIPELINE_STATE_STREAM_DESC desc
@@ -165,7 +165,7 @@ namespace stf
             };
             ComPtr<ID3D12PipelineState> raw = nullptr;
             ThrowIfFailed(m_Device->CreatePipelineState(&desc, IID_PPV_ARGS(raw.GetAddressOf())));
-            return PipelineState(PipelineState::CreationParams{ std::move(raw) });
+            return MakeShared<PipelineState>(PipelineState::CreationParams{ std::move(raw) });
         }
 
         RootSignature CreateRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC& InDesc) const;

--- a/src/Public/D3D12/GPUDevice.h
+++ b/src/Public/D3D12/GPUDevice.h
@@ -140,7 +140,7 @@ namespace stf
         CommandList CreateCommandList(D3D12_COMMAND_LIST_TYPE InType, std::string_view InName = "DefaultCommandList") const;
         CommandQueue CreateCommandQueue(const D3D12_COMMAND_QUEUE_DESC& InDesc, const std::string_view InName = "DefaultCommandQueue") const;
 
-        GPUResource CreateCommittedResource(
+        SharedPtr<GPUResource> CreateCommittedResource(
             const D3D12_HEAP_PROPERTIES& InHeapProps,
             const D3D12_HEAP_FLAGS InFlags,
             const D3D12_RESOURCE_DESC1& InResourceDesc,

--- a/src/Public/D3D12/GPUDevice.h
+++ b/src/Public/D3D12/GPUDevice.h
@@ -168,8 +168,8 @@ namespace stf
             return MakeShared<PipelineState>(PipelineState::CreationParams{ std::move(raw) });
         }
 
-        RootSignature CreateRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC& InDesc) const;
-        RootSignature CreateRootSignature(const CompiledShaderData& InShader) const;
+        SharedPtr<RootSignature> CreateRootSignature(const D3D12_VERSIONED_ROOT_SIGNATURE_DESC& InDesc) const;
+        SharedPtr<RootSignature> CreateRootSignature(const CompiledShaderData& InShader) const;
 
         void CreateShaderResourceView(const GPUResource& InResource, const DescriptorHandle InHandle) const;
         void CreateUnorderedAccessView(const GPUResource& InResource, const D3D12_UNORDERED_ACCESS_VIEW_DESC& InDesc, const DescriptorHandle InHandle) const;

--- a/src/Public/D3D12/GPUResource.h
+++ b/src/Public/D3D12/GPUResource.h
@@ -1,7 +1,6 @@
 #pragma once
-
-#include "Utility/MoveOnly.h"
 #include "Platform.h"
+#include "Utility/Object.h"
 #include "Utility/Pointer.h"
 
 #include <optional>
@@ -35,10 +34,9 @@ namespace stf
         MappedResource& operator=(const MappedResource&) = delete;
         ~MappedResource();
 
-        template<typename ThisType>
-        std::span<const std::byte> Get(this ThisType&& InThis)
+        std::span<const std::byte> Get() const
         {
-            return std::forward<ThisType>(InThis).m_MappedData;
+            return m_MappedData;
         }
 
     private:
@@ -47,7 +45,7 @@ namespace stf
         std::span<const std::byte> m_MappedData;
     };
 
-    class GPUResource : MoveOnly
+    class GPUResource : Object
     {
     public:
 

--- a/src/Public/D3D12/Shader/PipelineState.h
+++ b/src/Public/D3D12/Shader/PipelineState.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "Utility/MoveOnly.h"
+#include "Utility/Object.h"
 #include "Utility/Pointer.h"
 
 #include <d3d12.h>
 
 namespace stf
 {
-    class PipelineState : MoveOnly
+    class PipelineState : Object
     {
     public:
 
@@ -19,16 +19,14 @@ namespace stf
         PipelineState() = default;
         PipelineState(CreationParams InParams) noexcept;
 
-        template<typename ThisType>
-        ID3D12PipelineState* GetRaw(this ThisType&& InThis)
+        ID3D12PipelineState* GetRaw() const
         {
-            return std::forward<ThisType>(InThis).m_Raw.Get();
+            return m_Raw.Get();
         }
 
-        template<typename ThisType>
-        operator ID3D12PipelineState* (this ThisType&& InThis)
+        operator ID3D12PipelineState* () const
         {
-            return std::forward<ThisType>(InThis).GetRaw();
+            return GetRaw();
         }
 
         D3D12_CACHED_PIPELINE_STATE GetCachedState() const;

--- a/src/Public/D3D12/Shader/RootSignature.h
+++ b/src/Public/D3D12/Shader/RootSignature.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Platform.h"
-#include "Utility/MoveOnly.h"
+#include "Utility/Object.h"
 #include "Utility/Pointer.h"
 
 #include <unordered_map>
@@ -10,7 +10,7 @@
 
 namespace stf
 {
-    class RootSignature : MoveOnly
+    class RootSignature : Object
     {
     public:
 

--- a/src/Public/Framework/ShaderTestFixture.h
+++ b/src/Public/Framework/ShaderTestFixture.h
@@ -127,7 +127,7 @@ namespace stf
         CompilationResult CompileShader(const std::string_view InName, const EShaderType InType, CompilationEnvDesc InCompileDesc, const bool InTakingCapture) const;
         CommandEngine CreateCommandEngine() const;
         SharedPtr<DescriptorHeap> CreateDescriptorHeap() const;
-        PipelineState CreatePipelineState(const RootSignature& InRootSig, IDxcBlob* InShader) const;
+        SharedPtr<PipelineState> CreatePipelineState(const RootSignature& InRootSig, IDxcBlob* InShader) const;
         Expected<ReflectionResults, ErrorTypeAndDescription> ProcessShaderReflection(const CompiledShaderData& InShaderData) const;
         Expected<void, ErrorTypeAndDescription> PopulateTestConstantBuffers(ReflectionResults& InOutReflectionResults, const std::span<const ShaderBinding> InBindings) const;
         SharedPtr<GPUResource> CreateAssertBuffer(const u64 InSizeInBytes) const;

--- a/src/Public/Framework/ShaderTestFixture.h
+++ b/src/Public/Framework/ShaderTestFixture.h
@@ -126,7 +126,7 @@ namespace stf
 
         CompilationResult CompileShader(const std::string_view InName, const EShaderType InType, CompilationEnvDesc InCompileDesc, const bool InTakingCapture) const;
         CommandEngine CreateCommandEngine() const;
-        DescriptorHeap CreateDescriptorHeap() const;
+        SharedPtr<DescriptorHeap> CreateDescriptorHeap() const;
         PipelineState CreatePipelineState(const RootSignature& InRootSig, IDxcBlob* InShader) const;
         Expected<ReflectionResults, ErrorTypeAndDescription> ProcessShaderReflection(const CompiledShaderData& InShaderData) const;
         Expected<void, ErrorTypeAndDescription> PopulateTestConstantBuffers(ReflectionResults& InOutReflectionResults, const std::span<const ShaderBinding> InBindings) const;

--- a/src/Public/Framework/ShaderTestFixture.h
+++ b/src/Public/Framework/ShaderTestFixture.h
@@ -10,6 +10,7 @@
 #include "Framework/TestDataBufferProcessor.h"
 #include "Stats/StatSystem.h"
 #include "Utility/Expected.h"
+#include "Utility/Pointer.h"
 #include "Utility/TransparentStringHash.h"
 #include <optional>
 #include <vector>
@@ -137,7 +138,7 @@ namespace stf
 
         bool ShouldTakeCapture(const EGPUCaptureMode InCaptureMode, const bool InIsFailureRetry) const;
 
-        GPUDevice m_Device;
+        SharedPtr<GPUDevice> m_Device;
         ShaderCompiler m_Compiler;
         MultiTypeByteReaderMap m_ByteReaderMap;
         std::vector<ShaderMacro> m_Defines;

--- a/src/Public/Framework/ShaderTestFixture.h
+++ b/src/Public/Framework/ShaderTestFixture.h
@@ -130,8 +130,8 @@ namespace stf
         PipelineState CreatePipelineState(const RootSignature& InRootSig, IDxcBlob* InShader) const;
         Expected<ReflectionResults, ErrorTypeAndDescription> ProcessShaderReflection(const CompiledShaderData& InShaderData) const;
         Expected<void, ErrorTypeAndDescription> PopulateTestConstantBuffers(ReflectionResults& InOutReflectionResults, const std::span<const ShaderBinding> InBindings) const;
-        GPUResource CreateAssertBuffer(const u64 InSizeInBytes) const;
-        GPUResource CreateReadbackBuffer(const u64 InSizeInBytes) const;
+        SharedPtr<GPUResource> CreateAssertBuffer(const u64 InSizeInBytes) const;
+        SharedPtr<GPUResource> CreateReadbackBuffer(const u64 InSizeInBytes) const;
         DescriptorHandle CreateAssertBufferUAV(const GPUResource& InAssertBuffer, const DescriptorHeap& InHeap, const u32 InIndex) const;
         Results ReadbackResults(const GPUResource& InAllocationBuffer, const GPUResource& InAssertBuffer, const uint3 InDispatchDimensions, const TestDataBufferLayout& InTestDataLayout) const;
         void PopulateDefaultByteReaders();

--- a/src/Public/Framework/ShaderTestFixture.h
+++ b/src/Public/Framework/ShaderTestFixture.h
@@ -117,7 +117,7 @@ namespace stf
 
         struct ReflectionResults
         {
-            RootSignature RootSig;
+            SharedPtr<RootSignature> RootSig;
             std::unordered_map<std::string, BindingInfo, TransparentStringHash, std::equal_to<>> NameToBindingInfo;
             std::unordered_map<u32, std::vector<u32>> RootParamBuffers;
         };

--- a/src/Public/Utility/Object.h
+++ b/src/Public/Utility/Object.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace stf
+{
+    class Object
+    {
+    public:
+        Object() = default;
+        Object(const Object&) = delete;
+        Object(Object&&) = delete;
+
+        Object& operator=(const Object&) = delete;
+        Object& operator=(Object&&) = delete;
+    };
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -202,6 +202,7 @@ set(SOURCES
     Private/Utility/EnumReflectionTests.cpp
     Private/Utility/FunctionTraitsTests.cpp
     Private/Utility/LambdaTests.cpp
+    Private/Utility/ObjectTests.cpp
     Private/Utility/TupleTests.cpp
     Private/Utility/TypeListTests.cpp
     Private/Utility/TypeTraitsTests.cpp

--- a/test/Private/Utility/ObjectTests.cpp
+++ b/test/Private/Utility/ObjectTests.cpp
@@ -1,0 +1,23 @@
+
+#include <Utility/Object.h>
+
+#include <utility>
+
+namespace ObjectTests
+{
+    template<typename T>
+    concept NotObjectType = requires(T InA, T InB)
+    {
+        { T{ InA } };
+        { T{ std::move(InB) } };
+        { InA = InB };
+        { InA = std::move(InB) };
+    };
+
+    template<typename T>
+    concept ObjectType = !NotObjectType<T>;
+
+    struct TestObject : private stf::Object {};
+
+    static_assert(ObjectType<TestObject>, "Expected a class that inherits from stf::Object to conform to this concept");
+}


### PR DESCRIPTION
Essentially modifying the main D3D wrapper classes to be "objects"
This is to allow for easier relationship creation which will make prototyping easier.